### PR TITLE
Swap columns or rows on repaint

### DIFF
--- a/src/em-ui/imageViewer/EMImageViewerCanvas2.ts
+++ b/src/em-ui/imageViewer/EMImageViewerCanvas2.ts
@@ -14,11 +14,13 @@ export class EMImageViewerCanvas2 extends HTMLElement {
     ];
   }
 
-  private index: number = 0; // Current position on the image (top/left corner)
-  private limitLeft:number = 0;
-  private limitRight:number = 256;
-  private limitTop:number = 0;
-  private limitBottom:number = 256;
+  private index: number = 0; // Current top/left tile
+  private previousStartingColumn: number = 0;
+  private previousStartingRow: number = 0;
+  private limitLeft: number = 0;
+  private limitRight: number = 256;
+  private limitTop: number = 0;
+  private limitBottom: number = 256;
 
   private columns: Array<HTMLElement>[] = [];
   private rows: Array<HTMLElement>[] = [];
@@ -228,6 +230,28 @@ export class EMImageViewerCanvas2 extends HTMLElement {
     }
   }
 
+  private moveFirstColumnToEnd(): void {
+    const rows: HTMLCollection = this.tiles.children;
+
+    for (let i=0; i<rows.length; i++) {
+      const row = rows[i];
+      const tile = row.removeChild(row.firstElementChild);
+      tile.setAttribute('src', '');
+      row.append(tile);
+    }
+  }
+
+  private moveLastColumnToStart(): void {
+    const rows: HTMLCollection = this.tiles.children;
+
+    for (let i=0; i<rows.length; i++) {
+      const row = rows[i];
+      const tile = row.removeChild(row.lastElementChild);
+      tile.setAttribute('src', '');
+      row.prepend(tile);
+    }
+  }
+
   public setLocation(x: number, y: number) {
     const tileWidth: number = this.tileWidth;
     const imageColumnCount: number = Math.ceil(this.imageWidth / tileWidth);
@@ -237,7 +261,6 @@ export class EMImageViewerCanvas2 extends HTMLElement {
     const yPos: number = y < 0 ? 0 : y > this.imageHeight ? this.imageHeight : y;
 
     const startingColumn: number = Math.floor(xPos / tileWidth);
-
     const startingRow: number = Math.floor(yPos / tileWidth);
 
     // const index:number = this.imageColumnCount * this.previousYPos + this.previousXPos;
@@ -251,7 +274,15 @@ export class EMImageViewerCanvas2 extends HTMLElement {
       return;
     }
     
+    if (startingColumn > this.previousStartingColumn) {
+      this.moveFirstColumnToEnd();
+    } else if (startingColumn < this.previousStartingColumn) {
+      this.moveLastColumnToStart();
+    }
+
     this.index = index;
+    this.previousStartingColumn = startingColumn;
+    this.previousStartingRow = startingRow;
     this.refreshImage();
   }
 

--- a/src/em-ui/imageViewer/EMImageViewerCanvas2.ts
+++ b/src/em-ui/imageViewer/EMImageViewerCanvas2.ts
@@ -231,7 +231,7 @@ export class EMImageViewerCanvas2 extends HTMLElement {
   }
 
   private moveFirstColumnToEnd(): void {
-    const rows: HTMLCollection = this.tiles.children;
+    const rows = this.tiles.children;
 
     for (let i=0; i<rows.length; i++) {
       const row = rows[i];
@@ -242,7 +242,7 @@ export class EMImageViewerCanvas2 extends HTMLElement {
   }
 
   private moveLastColumnToStart(): void {
-    const rows: HTMLCollection = this.tiles.children;
+    const rows = this.tiles.children;
 
     for (let i=0; i<rows.length; i++) {
       const row = rows[i];
@@ -252,13 +252,44 @@ export class EMImageViewerCanvas2 extends HTMLElement {
     }
   }
 
+  private clearRowTiles(row: HTMLElement): HTMLElement {
+    const tiles = row.children;
+
+    for (let i=0; i<tiles.length; i++) {
+      const tile = tiles[i];
+      tile.setAttribute('src', '');
+    }
+
+    return row;
+  }
+
+  private moveFirstRowToEnd(): void {
+    if (this.tiles.childElementCount < 2) {
+      return;
+    }
+
+    this.tiles.append(
+      this.clearRowTiles(this.tiles.firstChild as HTMLElement)
+    );
+  }
+
+  private moveLastRowToStart(): void {
+    if (this.tiles.childElementCount < 2) {
+      return;
+    }
+    
+    this.tiles.prepend(
+      this.clearRowTiles(this.tiles.lastChild as HTMLElement)
+    );
+  }
+
   public setLocation(x: number, y: number) {
     const tileWidth: number = this.tileWidth;
     const imageColumnCount: number = Math.ceil(this.imageWidth / tileWidth);
 
     // Ensure that the position does not go below 0 or higher than the image width and height
     const xPos: number = x < this.limitLeft ? this.limitLeft : x > this.limitRight ? this.limitRight : x;
-    const yPos: number = y < 0 ? 0 : y > this.imageHeight ? this.imageHeight : y;
+    const yPos: number = y < this.limitTop ? this.limitTop : y > this.limitBottom ? this.limitBottom : y;
 
     const startingColumn: number = Math.floor(xPos / tileWidth);
     const startingRow: number = Math.floor(yPos / tileWidth);
@@ -280,6 +311,12 @@ export class EMImageViewerCanvas2 extends HTMLElement {
       this.moveLastColumnToStart();
     }
 
+    if (startingRow > this.previousStartingRow) {
+      this.moveFirstRowToEnd();
+    } else if (startingRow < this.previousStartingRow) {
+      this.moveLastRowToStart();
+    }
+
     this.index = index;
     this.previousStartingColumn = startingColumn;
     this.previousStartingRow = startingRow;
@@ -290,7 +327,6 @@ export class EMImageViewerCanvas2 extends HTMLElement {
     name: string,
     oldValue: string,
     newValue: string,
-    namespace: string,
   ): void {
     if (oldValue === newValue) {
       return;

--- a/tests/EMImageViewerCanvas.test.js
+++ b/tests/EMImageViewerCanvas.test.js
@@ -3,6 +3,16 @@ import { EMImageViewerCanvas2 } from "/build/scripts/bundle.js";
 import { TestUtils } from "./test-utils.js";
 
 describe('Image Viewer Canvas', () => {
+  const canvasAttributes_1 = {
+    'file-extension': 'jpg',
+    'image-height': '1367',
+    'image-prefix': 'i_l_',
+    'image-width': '2048',
+    'resources-uri': '/build/images/tiles/',
+    style: 'height:280px;width: 360px;',
+    'tile-width': '128',
+  };
+
   it('adds the EMImageViewerCanvas when no attributes are provided', async () => {
     const imageViewerCanvas = await TestUtils.render(
       EMImageViewerCanvas2.is,
@@ -13,16 +23,7 @@ describe('Image Viewer Canvas', () => {
   });
 
   it('initializes a grid of 4x4 when the component has a width equal 360px to and the height equal to 280px', async () => {
-    const attributes = {
-      'file-extension': 'jpg',
-      'image-height': '1367',
-      'image-prefix': 'i_l_',
-      'image-width': '2048',
-      'resources-uri': '/build/images/tiles/',
-      style: 'height:280px;width: 360px;',
-      'tile-width': '128',
-    };
-
+    const attributes = {...canvasAttributes_1};
     const imageViewerCanvas = await TestUtils.render(EMImageViewerCanvas2.is, attributes);
     
     const {shadowRoot} = imageViewerCanvas;
@@ -31,7 +32,39 @@ describe('Image Viewer Canvas', () => {
     expect(rows.length).to.equal(4);
     
     for (let i=0; i<rows.length; i++) {
-      expect(rows[i].childElementCount).to.equal(4)
+      expect(rows[i].childElementCount).to.equal(4);
     }
+  });
+
+  it('moves the first column to the end when the tile width is 128px and the position changes from {x: 0, y: 0} to {x:129, y:0}', async () => {
+    const attributes = {...canvasAttributes_1};
+    const imageViewerCanvas = await TestUtils.render(EMImageViewerCanvas2.is, attributes);
+    
+    const {shadowRoot} = imageViewerCanvas;
+    const rows = [...shadowRoot.querySelector('[tiles]').children];
+    const firstColumnTiles = rows.map((row) => row.firstElementChild);
+
+    imageViewerCanvas.setLocation(129, 0);
+
+    rows.forEach((row, index) => {
+      expect(row.lastElementChild === firstColumnTiles[index]).to.be.ok;
+    });
+  });
+
+  it('moves the last column to the start when the tile width is 128px and the position changes from {x: 129, y: 0} to {x:0, y:0}', async () => {
+    const attributes = {...canvasAttributes_1};
+    const imageViewerCanvas = await TestUtils.render(EMImageViewerCanvas2.is, attributes);
+    
+    const {shadowRoot} = imageViewerCanvas;
+    imageViewerCanvas.setLocation(129, 0);
+
+    const rows = [...shadowRoot.querySelector('[tiles]').children];
+    const lastColumnTiles = rows.map((row) => row.lastElementChild);
+
+    imageViewerCanvas.setLocation(0, 0);
+
+    rows.forEach((row, index) => {
+      expect(row.firstElementChild === lastColumnTiles[index]).to.be.ok;
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/EddieMachete/em-ui-quadrant/issues/4

## Description

When the image needed refreshing, I was moving all of the tiles as a group and updating the src. As the refresh is not instant, even when tiles are cached, it made the image jump on refresh. To avoid that, when re-paint is needed, I either swap the first and last rows or columns and update them.

## Tasks
- [x] Add method to move the first column to the end when the tile width is 128px and the position changes from {x: 0, y: 0} to {x:129, y:0}
- [x] Add method to move the last column to the start when the tile width is 128px and the position changes from {x: 129, y: 0} to {x:0, y:0}
- [x] Add method to move first row to end
- [x] Add method to move last row to start